### PR TITLE
Make session usage a configurable option

### DIFF
--- a/pysomneo/__init__.py
+++ b/pysomneo/__init__.py
@@ -27,17 +27,27 @@ class Somneo(object):
     Class represents the Somneo wake-up light.
     """
 
-    def __init__(self, host=None):
+    def __init__(self, host=None, use_session=True):
         """Initialize."""
         urllib3.disable_warnings()
         self.host = host
         self._base_url = 'https://' + host + '/di/v1/products/1/'
-        self._session = requests.Session()
+        self._requests_session = None
+        self._use_session = use_session
 
         self.light_data = None
         self.sensor_data = None
         self.alarm_data = dict()
         self.snoozetime = None
+
+    @property
+    def _session(self):
+        if self._use_session:
+            if self._requests_session is None:
+                self._requests_session = requests.Session()
+            return self._requests_session
+        else:
+            return requests
 
     def get_device_info(self):
         """ Get Device information """


### PR DESCRIPTION
In light of #8, it seems some Somneo units are not very robust to persistent sessions. My HF367x certainly isn't. This change makes it possible to disable use of the `requests.Session()` object.