### PR TITLE
Allow empty dusk light theme to be added to config, this is the default when first connecting to a wake up light

### DIFF
--- a/pysomneo/__init__.py
+++ b/pysomneo/__init__.py
@@ -85,8 +85,8 @@ class Somneo(object):
 
         response = self._get('files/dusklightthemes')
         for idx, item in enumerate(response.values()):
-            if item['name']:
-                self._dusk_light_themes.update({item['name'].lower(): idx})
+            # Empty name is a valid theme, so we add this as well if the response returns it
+            self._dusk_light_themes.update({item['name'].lower(): idx})
 
         response = self._get('files/wakeup')
         for idx, item in enumerate(response.values()):


### PR DESCRIPTION
This is opened to address this [issue](https://github.com/theneweinstein/somneo/issues/65). I have tested it in my home assistant environment and that works