### PR TITLE
fix: set_player_source always turns on the player

### DIFF
--- a/pysomneo/somneo.py
+++ b/pysomneo/somneo.py
@@ -626,7 +626,6 @@ class Somneo(object):
         if not self.player:
             self._fetch_player_data()
 
-        previous_state = self.player["onoff"]
         previous_sndch = self.player["sndch"]
         sunset_settings = dict(self.sunset_data)
 
@@ -650,7 +649,7 @@ class Somneo(object):
             "snddv": snddv,
             "sndch": sndch,
             "sndss": 0,
-            "onoff": previous_state,
+            "onoff": True,
             "tempy": False,
         }
 

--- a/pysomneo/somneo.py
+++ b/pysomneo/somneo.py
@@ -618,13 +618,20 @@ class Somneo(object):
         self._fetch_player_data()
         self._fetch_sensor_data()
 
-    def set_player_source(self, source: str):
+    def set_player_source(self, source: str | int):
         """
         Set the source of the player, either 'aux'
-        or preset 1..5 or one of the dusk sound theme
+        or preset 1..5 (int or 'FM N' string) or one of the dusk sound theme
         """
         if not self.player:
             self._fetch_player_data()
+
+        # Support legacy int sources (1..5 = FM presets)
+        if isinstance(source, int):
+            if source in range(1, 6):
+                source = f"FM {source}"
+            else:
+                raise ValueError(f"Unsupported player source: {source}")
 
         previous_sndch = self.player["sndch"]
         sunset_settings = dict(self.sunset_data)


### PR DESCRIPTION
## Problem

When calling `set_player_source()` while the player is off, the method preserves the previous on/off state (`'onoff': previous_state`). This means selecting a source silently keeps the player off — it appears as if nothing happened.

This is especially problematic when called from Home Assistant's `media_player.select_source` service, where users expect selecting a source to also start playback.

## Root Cause

In `set_player_source()`, the payload sends `'onoff': previous_state` (line 653), which is `False` when the player was off. The Somneo device accepts the command but does not start playing.

## Fix

Changed `'onoff': previous_state` to `'onoff': True` so that selecting a source always turns the player on. This matches user expectation: if you select a source, you want to hear it.

Removed the now-unused `previous_state` variable.

## Testing

Tested on a Philips Somneo HF3650 with pysomneo 4.2.4 (same bug exists in 5.0.2):

```python
s = Somneo('192.168.178.26')
s.fetch_data()
s.toggle_player(False)  # Player off
s.set_player_source(1)  # Select FM 1
s.fetch_data()
print(s.player['onoff'])  # Before fix: False, After fix: True
```